### PR TITLE
adding check if tags is present in vpc response

### DIFF
--- a/src/aws_cidr_finder/boto_wrapper.py
+++ b/src/aws_cidr_finder/boto_wrapper.py
@@ -71,7 +71,7 @@ class BotoWrapper:
                 subnets=_parse_subnet_cidrs(
                     self._get_subnet_cidrs(vpc["VpcId"])["Subnets"], ipv6=ipv6
                 )
-            ) for vpc in vpcs
+            ) for vpc in vpcs if 'Tags' in vpc
         ]
 
     def _get_subnet_cidrs(self, vpc_id: str) -> DescribeSubnetsResultTypeDef:  # pragma: no cover


### PR DESCRIPTION
fix for 
aws-cidr-finder --profile xyz --region us-east-1 
Traceback (most recent call last):
  File "/opt/homebrew/bin/aws-cidr-finder", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/lib/python3.10/site-packages/aws_cidr_finder/__main__.py", line 74, in main
    subnet_cidr_gaps, cidrs_not_converted_to_prefix, messages = boto.get_subnet_cidr_gaps(
  File "/opt/homebrew/lib/python3.10/site-packages/aws_cidr_finder/boto_wrapper.py", line 87, in get_subnet_cidr_gaps
    for vpc in core.split_out_individual_cidrs(self._get_vpc_data(ipv6=ipv6)):
  File "/opt/homebrew/lib/python3.10/site-packages/aws_cidr_finder/boto_wrapper.py", line 66, in _get_vpc_data
    return [
  File "/opt/homebrew/lib/python3.10/site-packages/aws_cidr_finder/boto_wrapper.py", line 69, in <listcomp>
    name=_get_vpc_name(vpc["Tags"]),
KeyError: 'Tags'
